### PR TITLE
When checking for a current active url, the url string is only analys…

### DIFF
--- a/src/Frontend/Content/Menus/MenuItem.php
+++ b/src/Frontend/Content/Menus/MenuItem.php
@@ -147,7 +147,7 @@ class MenuItem
             $currentPath = rtrim($currentPath, '/');
         }
 
-        if (!empty($currentPath) && strpos($this->getUrl(), $currentPath) !== false) {
+        if (!empty($currentPath) && substr($this->getUrl(), -strlen($currentPath)) == $currentPath) {
             return true;
         }
 

--- a/src/Frontend/Content/Menus/MenuItem.php
+++ b/src/Frontend/Content/Menus/MenuItem.php
@@ -147,6 +147,8 @@ class MenuItem
             $currentPath = rtrim($currentPath, '/');
         }
 
+        // We check the $currentPath isn't empty, then check if the $currentPath is at the end of the current url
+        // The - on strlen ensures we use the end of the string for comparison rather than the start
         if (!empty($currentPath) && substr($this->getUrl(), -strlen($currentPath)) == $currentPath) {
             return true;
         }


### PR DESCRIPTION
When checking for a current active url, the url string is only analysed on the end of the current URL, not anywhere in the URL. This fixes a bug where the current active URL would sometimes produce false positives