### PR TITLE
Hotfix/document filesize

### DIFF
--- a/src/Frontend/Cms/Wordpress.php
+++ b/src/Frontend/Cms/Wordpress.php
@@ -657,7 +657,11 @@ class Wordpress extends ContentRepository
                         return $document;
                     } elseif (is_array($value)) {
                         //given array of data, create field directy
-                        $filesize = FileInfoFormatter::formatFileSize($value['filesize']);
+                        if ( isset($value['filesize'])) {
+                            $filesize = FileInfoFormatter::formatFileSize($value['filesize']);
+                        } else {
+                            $filesize = $this->api->getMediaFileSize($value['url']);
+                        }
 
                         $document = new Document(
                             $name,

--- a/src/Frontend/Cms/Wordpress.php
+++ b/src/Frontend/Cms/Wordpress.php
@@ -657,7 +657,7 @@ class Wordpress extends ContentRepository
                         return $document;
                     } elseif (is_array($value)) {
                         //given array of data, create field directy
-                        if ( isset($value['filesize'])) {
+                        if (isset($value['filesize'])) {
                             $filesize = FileInfoFormatter::formatFileSize($value['filesize']);
                         } else {
                             $filesize = $this->api->getMediaFileSize($value['url']);

--- a/tests/Frontend/Cms/WordPressTest.php
+++ b/tests/Frontend/Cms/WordPressTest.php
@@ -100,12 +100,11 @@ class WordPressTest extends TestCase
             ),
             new Response(
                 200,
-                [],
-                file_get_contents(__DIR__ . '/../responses/acf/media/media.81.json')
+                ['Content-length' => 23857 ]
             ),
             new Response(
                 200,
-                ['Content-length' => 23857 ]
+                ['Content-length' => 169812 ]
             ),
             new Response(
                 200,
@@ -171,7 +170,7 @@ class WordPressTest extends TestCase
         // Test documents
         $docs = $page->getContent()->get('project_documents');
         $this->assertInstanceOf('Studio24\Frontend\Content\Field\ArrayContent', $docs);
-        $this->assertEquals(2, count($docs));
+        $this->assertEquals(3, count($docs));
 
         foreach ($docs as $key => $item) {
             $doc = $item->get('project_documents_project_documents_document');

--- a/tests/Frontend/Cms/WordPressTest.php
+++ b/tests/Frontend/Cms/WordPressTest.php
@@ -100,6 +100,11 @@ class WordPressTest extends TestCase
             ),
             new Response(
                 200,
+                [],
+                file_get_contents(__DIR__ . '/../responses/acf/media/media.81.json')
+            ),
+            new Response(
+                200,
                 ['Content-length' => 23857 ]
             ),
             new Response(
@@ -183,6 +188,9 @@ class WordPressTest extends TestCase
                     $this->assertEquals("timeline - IRIS Education website roll out", $doc->getTitle());
                     $this->assertEquals("165.83 KB", $doc->getFileSize());
                     $this->assertEmpty($doc->getDescription());
+                    break;
+                case 2:
+                    $this->assertEquals("165.83 KB", $doc->getFileSize());
                     break;
             }
         }

--- a/tests/Frontend/responses/acf/projects.json
+++ b/tests/Frontend/responses/acf/projects.json
@@ -92,7 +92,7 @@
                         "type": "application",
                         "subtype": "pdf",
                         "icon": "http://local.wp-api.test/wp-includes/images/media/document.png"
-                    },
+                    }
                 }
             ],
             "project_video": 3496,

--- a/tests/Frontend/responses/acf/projects.json
+++ b/tests/Frontend/responses/acf/projects.json
@@ -69,6 +69,30 @@
                         "subtype": "pdf",
                         "icon": "http://local.wp-api.test/wp-includes/images/media/document.png"
                     }
+                },
+                {
+                    "project_documents_project_documents_document": {
+                        "ID": 81,
+                        "id": 81,
+                        "title": "timeline - IRIS Education website roll out",
+                        "filename": "timeline-IRIS-Education-website-roll-out-.pdf",
+                        "url": "http://local.wp-api.test/wp-content/uploads/2019/03/timeline-IRIS-Education-website-roll-out-.pdf",
+                        "link": "http://local.wp-api.test/test-acf/timeline-iris-education-website-roll-out/",
+                        "alt": "",
+                        "author": "1",
+                        "description": "",
+                        "caption": "",
+                        "name": "timeline-iris-education-website-roll-out",
+                        "status": "inherit",
+                        "uploaded_to": 79,
+                        "date": "2019-03-01 14:24:53",
+                        "modified": "2019-03-01 14:26:42",
+                        "menu_order": 0,
+                        "mime_type": "application/pdf",
+                        "type": "application",
+                        "subtype": "pdf",
+                        "icon": "http://local.wp-api.test/wp-includes/images/media/document.png"
+                    },
                 }
             ],
             "project_video": 3496,


### PR DESCRIPTION
Fix to get document filesize if not in array provided in API response (filesize must be missing in older versions of WP)