### PR TITLE
allow to pass a yaml file as content field definition

### DIFF
--- a/src/Frontend/ContentModel/ContentFieldCollectionInterface.php
+++ b/src/Frontend/ContentModel/ContentFieldCollectionInterface.php
@@ -5,5 +5,5 @@ namespace Studio24\Frontend\ContentModel;
 
 interface ContentFieldCollectionInterface
 {
-    public function parseContentFieldArray(string $name, array $data): FieldInterface;
+    public function parseContentFieldArray(string $name, array $data, string $configDir): FieldInterface;
 }

--- a/src/Frontend/ContentModel/ContentType.php
+++ b/src/Frontend/ContentModel/ContentType.php
@@ -91,6 +91,7 @@ class ContentType extends \ArrayIterator implements ContentFieldCollectionInterf
      */
     public function parseConfig(string $file): ContentType
     {
+        $configDir = dirname($file);
         $data = Yaml::parseFile($file);
 
         if (!is_array($data)) {
@@ -98,6 +99,9 @@ class ContentType extends \ArrayIterator implements ContentFieldCollectionInterf
         }
 
         foreach ($data as $name => $values) {
+            if (is_string($values)) {
+                $values = Yaml::parseFile($configDir.'/'.$values);
+            }
             if (!is_array($values)) {
                 throw new ConfigParsingException(sprintf("Content field definition must contain an array of values, including the 'type' property, %s found", gettype($values)));
             }

--- a/src/Frontend/ContentModel/ContentType.php
+++ b/src/Frontend/ContentModel/ContentType.php
@@ -99,13 +99,10 @@ class ContentType extends \ArrayIterator implements ContentFieldCollectionInterf
         }
 
         foreach ($data as $name => $values) {
-            if ($name = 'config') {
-                $values = Yaml::parseFile($configDir.'/'.$values);
-            }
             if (!is_array($values)) {
                 throw new ConfigParsingException(sprintf("Content field definition must contain an array of values, including the 'type' property, %s found", gettype($values)));
             }
-            $this->addItem($this->parseContentFieldArray($name, $values));
+            $this->addItem($this->parseContentFieldArray($name, $values, $configDir));
         }
 
         return $this;
@@ -116,11 +113,15 @@ class ContentType extends \ArrayIterator implements ContentFieldCollectionInterf
      *
      * @param string $name
      * @param array $data
+     * @param string $configDir
      * @return FieldInterface
      * @throws ConfigParsingException
      */
-    public function parseContentFieldArray(string $name, array $data): FieldInterface
+    public function parseContentFieldArray(string $name, array $data, string $configDir = ''): FieldInterface
     {
+        if (isset($data['config'])) {
+            $data = YAML::parseFile($configDir.'/'.$data['config']);
+        }
         if (!isset($data['type'])) {
             throw new ConfigParsingException("You must set a 'type' for a content type, e.g. type: plaintext");
         }

--- a/src/Frontend/ContentModel/ContentType.php
+++ b/src/Frontend/ContentModel/ContentType.php
@@ -99,7 +99,7 @@ class ContentType extends \ArrayIterator implements ContentFieldCollectionInterf
         }
 
         foreach ($data as $name => $values) {
-            if (is_string($values)) {
+            if ($name = 'config') {
                 $values = Yaml::parseFile($configDir.'/'.$values);
             }
             if (!is_array($values)) {

--- a/tests/Frontend/ContentModel/ContentModelTest.php
+++ b/tests/Frontend/ContentModel/ContentModelTest.php
@@ -121,4 +121,80 @@ class ContentModelTest extends TestCase
             $x++;
         }
     }
+
+    public function testYamlConfigKey()
+    {
+        $contentModel = new ContentModel(__DIR__ . '/config/content_model_flexible_components.yaml');
+
+        $d = 1;
+        foreach ($contentModel as $contentType) {
+            switch ($d) {
+                case 1:
+                    //should be the news contentType
+                    $c = 1;
+                    foreach ($contentType as $contentField) {
+                        switch ($c) {
+                            case 1:
+                                $this->assertEquals('post_type', $contentField->getName());
+                                $this->assertEquals('plaintext', $contentField->getType());
+                                break;
+                            case 16:
+                                $this->assertEquals('page_content', $contentField->getName());
+                                $this->assertEquals('flexible', $contentField->getType());
+
+                                $b = 1;
+                                foreach ($contentField as $component) {
+                                    switch ($b) {
+                                        case 1:
+                                            $this->assertEquals('fullbleed', $component->getName());
+
+                                            $a = 1;
+                                            foreach ($component as $componentContentFields) {
+                                                switch ($a) {
+                                                    case 1:
+                                                        $this->assertEquals('title', $componentContentFields->getName());
+                                                        $this->assertEquals('text', $componentContentFields->getType());
+                                                        break;
+                                                    case 2:
+                                                        $this->assertEquals('bg_image', $componentContentFields->getName());
+                                                        $this->assertEquals('image', $componentContentFields->getType());
+                                                }
+                                                $a++;
+                                            }
+                                            break;
+                                        case 4:
+                                            $this->assertEquals('donation_block', $component->getName());
+
+                                            $a = 1;
+                                            foreach ($component as $componentContentFields) {
+                                                switch ($a) {
+                                                    case 1:
+                                                        $this->assertEquals('title', $componentContentFields->getName());
+                                                        $this->assertEquals('text', $componentContentFields->getType());
+                                                        break;
+                                                    case 2:
+                                                        $this->assertEquals('text', $componentContentFields->getName());
+                                                        $this->assertEquals('text', $componentContentFields->getType());
+                                                }
+                                                $a++;
+                                            }
+                                            break;
+                                        default:
+                                            break;
+                                    }
+                                    $b++;
+                                }
+                                break;
+                            default:
+                                break;
+                        }
+                        $c++;
+                    }
+                    break;
+                default:
+                    break;
+            }
+            $d++;
+        }
+    }
 }

--- a/tests/Frontend/ContentModel/config/content_model_flexible_components.yaml
+++ b/tests/Frontend/ContentModel/config/content_model_flexible_components.yaml
@@ -1,0 +1,18 @@
+content_types:
+  news:
+    api_endpoint: posts
+    content_fields: news-with-config-file.yaml
+  projects:
+    api_endpoint: projects
+    content_fields: projects.yaml
+
+global:
+  test: myValue
+  image_thumbnails:
+    - thumbnail
+    - medium
+    - medium_large
+    - large
+    - twentyseventeen-featured-image
+    - twentyseventeen-thumbnail-avatar
+    - issue-post-image

--- a/tests/Frontend/ContentModel/config/flexible-components.yaml
+++ b/tests/Frontend/ContentModel/config/flexible-components.yaml
@@ -1,0 +1,171 @@
+
+  type: flexible
+  components:
+    fullbleed:
+      title:
+        type: text
+      bg_image:
+        type: image
+      strapline:
+        type: text
+      appeal_type:
+        type: plaintext
+      include_button:
+        type: boolean
+      button_text:
+        type: plaintext
+      button_link:
+        type: plaintext
+      include_newsletter:
+        type: boolean
+      newsletter_source:
+        type: plaintext
+      add_bottom_margin:
+        type: boolean
+    statement_block:
+      statement_title:
+        type: text
+      statement:
+        type: richtext
+    content:
+      title:
+        type: text
+      content:
+        type: richtext
+      full_width:
+        type: boolean
+      trigger:
+        type: boolean
+      number_of_elements:
+        type: number
+    donation_block:
+      title:
+        type: text
+      text:
+        type: text
+      donation_amounts:
+        type: array
+        content_fields:
+          amount:
+            type: number
+          benefit:
+            type: text
+      regulator_text:
+        type: text
+      button_text:
+        type: text
+    highlight:
+      numbers_left:
+        type: text
+      numbers_left_description:
+        type: richtext
+      numbers_right:
+        type: text
+      numbers_right_description:
+        type: richtext
+    latest_news:
+      news_block:
+        type: boolean
+    membership_block:
+      title:
+        type: text
+      introduction:
+        type: text
+      membership_name:
+        type: text
+      benefits_introduction:
+        type: text
+      benefits:
+        type: array
+        content_fields:
+          benefit:
+            type: text
+      button_text:
+        type: text
+      membership_amount_monthly:
+        type: number
+      membership_amount_annual:
+        type: number
+    quote:
+      author:
+        type: relation
+        content_type: people
+      authors_quote:
+        type: text
+    feature_quote:
+      authors_quote:
+        type: text
+      author:
+        type: relation
+        content_type: people
+      author_link:
+        type: text
+      add_bottom_margin:
+        type: boolean
+    media_contact:
+      name:
+        type: text
+      job_title:
+        type: text
+      email:
+        type: text
+      phone:
+        type: text
+    reasons_to_donate:
+      reasons:
+        type: array
+        content_fields:
+          post_object:
+            type: relation
+            content_type: donation_reasons
+    documents_sidebar:
+      title:
+        type: text
+      add_sidebar:
+        type: array
+        content_fields:
+          external_resource:
+            type: boolean
+          post_object:
+            type: relation
+            content_type: document
+          external_link:
+            type: text
+          external_link_title:
+            type: text
+          related_post_link_title:
+            type: text
+    content_sidebar:
+      add_sidebar:
+        type: array
+        content_fields:
+          title:
+            type: text
+          content:
+            type: text
+    timeline:
+      timeline_title:
+        type: text
+      timeline:
+        type: array
+        content_fields:
+          year:
+            type: text
+          date_text:
+            type: text
+    video:
+      title:
+        type: text
+      video:
+        type: richtext
+      content:
+        type: text
+    ways_to_give:
+      ways_to_give:
+        type: relation
+        content_type: ways_to_give
+    newsletter_block:
+      introduction:
+        type: richtext
+      newsletter_source:
+        type: plaintext

--- a/tests/Frontend/ContentModel/config/flexible-components.yaml
+++ b/tests/Frontend/ContentModel/config/flexible-components.yaml
@@ -1,171 +1,170 @@
-
-  type: flexible
-  components:
-    fullbleed:
-      title:
-        type: text
-      bg_image:
-        type: image
-      strapline:
-        type: text
-      appeal_type:
-        type: plaintext
-      include_button:
-        type: boolean
-      button_text:
-        type: plaintext
-      button_link:
-        type: plaintext
-      include_newsletter:
-        type: boolean
-      newsletter_source:
-        type: plaintext
-      add_bottom_margin:
-        type: boolean
-    statement_block:
-      statement_title:
-        type: text
-      statement:
-        type: richtext
+type: flexible
+components:
+  fullbleed:
+    title:
+      type: text
+    bg_image:
+      type: image
+    strapline:
+      type: text
+    appeal_type:
+      type: plaintext
+    include_button:
+      type: boolean
+    button_text:
+      type: plaintext
+    button_link:
+      type: plaintext
+    include_newsletter:
+      type: boolean
+    newsletter_source:
+      type: plaintext
+    add_bottom_margin:
+      type: boolean
+  statement_block:
+    statement_title:
+      type: text
+    statement:
+      type: richtext
+  content:
+    title:
+      type: text
     content:
-      title:
-        type: text
-      content:
-        type: richtext
-      full_width:
-        type: boolean
-      trigger:
-        type: boolean
-      number_of_elements:
-        type: number
-    donation_block:
-      title:
-        type: text
-      text:
-        type: text
-      donation_amounts:
-        type: array
-        content_fields:
-          amount:
-            type: number
-          benefit:
-            type: text
-      regulator_text:
-        type: text
-      button_text:
-        type: text
-    highlight:
-      numbers_left:
-        type: text
-      numbers_left_description:
-        type: richtext
-      numbers_right:
-        type: text
-      numbers_right_description:
-        type: richtext
-    latest_news:
-      news_block:
-        type: boolean
-    membership_block:
-      title:
-        type: text
-      introduction:
-        type: text
-      membership_name:
-        type: text
-      benefits_introduction:
-        type: text
-      benefits:
-        type: array
-        content_fields:
-          benefit:
-            type: text
-      button_text:
-        type: text
-      membership_amount_monthly:
-        type: number
-      membership_amount_annual:
-        type: number
-    quote:
-      author:
-        type: relation
-        content_type: people
-      authors_quote:
-        type: text
-    feature_quote:
-      authors_quote:
-        type: text
-      author:
-        type: relation
-        content_type: people
-      author_link:
-        type: text
-      add_bottom_margin:
-        type: boolean
-    media_contact:
-      name:
-        type: text
-      job_title:
-        type: text
-      email:
-        type: text
-      phone:
-        type: text
-    reasons_to_donate:
-      reasons:
-        type: array
-        content_fields:
-          post_object:
-            type: relation
-            content_type: donation_reasons
-    documents_sidebar:
-      title:
-        type: text
-      add_sidebar:
-        type: array
-        content_fields:
-          external_resource:
-            type: boolean
-          post_object:
-            type: relation
-            content_type: document
-          external_link:
-            type: text
-          external_link_title:
-            type: text
-          related_post_link_title:
-            type: text
-    content_sidebar:
-      add_sidebar:
-        type: array
-        content_fields:
-          title:
-            type: text
-          content:
-            type: text
+      type: richtext
+    full_width:
+      type: boolean
+    trigger:
+      type: boolean
+    number_of_elements:
+      type: number
+  donation_block:
+    title:
+      type: text
+    text:
+      type: text
+    donation_amounts:
+      type: array
+      content_fields:
+        amount:
+          type: number
+        benefit:
+          type: text
+    regulator_text:
+      type: text
+    button_text:
+      type: text
+  highlight:
+    numbers_left:
+      type: text
+    numbers_left_description:
+      type: richtext
+    numbers_right:
+      type: text
+    numbers_right_description:
+      type: richtext
+  latest_news:
+    news_block:
+      type: boolean
+  membership_block:
+    title:
+      type: text
+    introduction:
+      type: text
+    membership_name:
+      type: text
+    benefits_introduction:
+      type: text
+    benefits:
+      type: array
+      content_fields:
+        benefit:
+          type: text
+    button_text:
+      type: text
+    membership_amount_monthly:
+      type: number
+    membership_amount_annual:
+      type: number
+  quote:
+    author:
+      type: relation
+      content_type: people
+    authors_quote:
+      type: text
+  feature_quote:
+    authors_quote:
+      type: text
+    author:
+      type: relation
+      content_type: people
+    author_link:
+      type: text
+    add_bottom_margin:
+      type: boolean
+  media_contact:
+    name:
+      type: text
+    job_title:
+      type: text
+    email:
+      type: text
+    phone:
+      type: text
+  reasons_to_donate:
+    reasons:
+      type: array
+      content_fields:
+        post_object:
+          type: relation
+          content_type: donation_reasons
+  documents_sidebar:
+    title:
+      type: text
+    add_sidebar:
+      type: array
+      content_fields:
+        external_resource:
+          type: boolean
+        post_object:
+          type: relation
+          content_type: document
+        external_link:
+          type: text
+        external_link_title:
+          type: text
+        related_post_link_title:
+          type: text
+  content_sidebar:
+    add_sidebar:
+      type: array
+      content_fields:
+        title:
+          type: text
+        content:
+          type: text
+  timeline:
+    timeline_title:
+      type: text
     timeline:
-      timeline_title:
-        type: text
-      timeline:
-        type: array
-        content_fields:
-          year:
-            type: text
-          date_text:
-            type: text
+      type: array
+      content_fields:
+        year:
+          type: text
+        date_text:
+          type: text
+  video:
+    title:
+      type: text
     video:
-      title:
-        type: text
-      video:
-        type: richtext
-      content:
-        type: text
+      type: richtext
+    content:
+      type: text
+  ways_to_give:
     ways_to_give:
-      ways_to_give:
-        type: relation
-        content_type: ways_to_give
-    newsletter_block:
-      introduction:
-        type: richtext
-      newsletter_source:
-        type: plaintext
+      type: relation
+      content_type: ways_to_give
+  newsletter_block:
+    introduction:
+      type: richtext
+    newsletter_source:
+      type: plaintext

--- a/tests/Frontend/ContentModel/config/news-with-config-file.yaml
+++ b/tests/Frontend/ContentModel/config/news-with-config-file.yaml
@@ -1,0 +1,35 @@
+post_type:
+  type: plaintext
+theme:
+  type: plaintext
+description:
+  type: text
+image:
+  type: image
+image_credit:
+  type: text
+banner_title:
+  type: text
+banner_text:
+  type: text
+video_loop:
+  type: plaintext
+video_poster:
+  type: image
+mini_summary:
+  type: richtext
+full_summary:
+  type: richtext
+environment:
+  type: relation
+  content_type: environment
+region:
+  type: relation
+  content_type: regions
+author:
+  type: relation
+  content_type: user
+featured:
+  type: boolean
+page_content:
+  config: flexible-components.yaml


### PR DESCRIPTION
Allows to import array of flexible components (for example) fro external yaml file, e.g.

```
author:
  type: relation
  content_type: user
featured:
  type: boolean
page_content: flexible-components.yaml
```