### PR TITLE
Hotfix/base field 404s

### DIFF
--- a/src/Frontend/Api/Providers/RestApi.php
+++ b/src/Frontend/Api/Providers/RestApi.php
@@ -76,6 +76,7 @@ class RestApi extends RestApiAbstract
      * @throws \Psr\SimpleCache\InvalidArgumentException
      * @throws \Studio24\Frontend\Exception\FailedRequestException
      * @throws \Studio24\Frontend\Exception\PermissionException
+     * @throws \Studio24\Frontend\Exception\NotFoundException
      */
     public function getOne($apiEndpoint, $id) : array
     {

--- a/src/Frontend/Api/RestApiAbstract.php
+++ b/src/Frontend/Api/RestApiAbstract.php
@@ -277,6 +277,7 @@ abstract class RestApiAbstract
      * @param array $options
      * @return ResponseInterface
      * @throws FailedRequestException
+     * @throws NotFoundException
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
     public function get($uri, array $options = []) : ResponseInterface

--- a/src/Frontend/Api/RestApiAbstract.php
+++ b/src/Frontend/Api/RestApiAbstract.php
@@ -58,6 +58,13 @@ abstract class RestApiAbstract
     protected $ignoreErrorCodes = [401];
 
     /**
+     * Default values for response error codes to ignore
+     *
+     * @var array
+     */
+    protected $defaultIgnoredErrorCodes = [401];
+
+    /**
      * Constructor
      *
      * @param string $baseUri API base URI
@@ -143,6 +150,18 @@ abstract class RestApiAbstract
     public function ignoreErrorCode(int $code)
     {
         $this->ignoreErrorCodes[] = $code;
+    }
+
+    /**
+     * Restore default error codes to be ignored in the response (and not throw an exception)
+     *
+     * Example use case: when querying a page that exists but has a featured media that does not exist (returns a 404),
+     * it's best to ignore the 404 error returned by the media query but revert to catching 404 errors for subsequent queries.
+     *
+     */
+    public function restoreDefaultIgnoredErrorCodes()
+    {
+        $this->ignoreErrorCodes = $this->defaultIgnoredErrorCodes;
     }
 
     /**

--- a/tests/Frontend/Api/FailedRequestsTest.php
+++ b/tests/Frontend/Api/FailedRequestsTest.php
@@ -10,6 +10,8 @@ use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
 use Studio24\Frontend\Api\Providers\Wordpress;
 use Studio24\Frontend\Api\Providers\RestApi;
+use Studio24\Frontend\Exception\ApiException;
+use Studio24\Frontend\Exception\NotFoundException;
 
 class FailedRequestsTest extends TestCase
 {
@@ -22,17 +24,7 @@ class FailedRequestsTest extends TestCase
                 401,
                 [],
                 '{"code":"rest_forbidden","message":"Sorry, you are not allowed to do that.","data":{"status":401}}'
-            ),
-            new Response(
-                404,
-                [],
-                '{"code":"rest_forbidden","message":"Sorry, you are not allowed to do that.","data":{"status":401}}'
-            ),
-            new Response(
-                500,
-                [],
-                'Exception error data not found'
-            ),
+            )
         ]);
 
         $handler = HandlerStack::create($mock);
@@ -121,5 +113,51 @@ class FailedRequestsTest extends TestCase
 
         $this->expectException(\Studio24\Frontend\Exception\FailedRequestException::class);
         $results = $api->getOne('endpoint', 1);
+    }
+
+    public function testResetIgnoreExceptionCodes()
+    {
+        // Create a mock and queue two responses
+        $mock = new MockHandler([
+            new Response(
+                404,
+                [],
+                '{"code":"rest_invalid_param","message":"page not found","data":{"status":404}}'
+            ),
+            new Response(
+                404,
+                [],
+                '{"code":"rest_invalid_param","message":"page not found","data":{"status":404}}'
+            ),
+            new Response(
+                404,
+                [],
+                'Exception error data not found'
+            ),
+        ]);
+
+        $handler = HandlerStack::create($mock);
+        $client = new Client(['handler' => $handler]);
+
+        $api = new RestApi('somewhere');
+        $api->setClient($client);
+
+        try {
+            $results = $api->getOne('endpoint', 1);
+            $this->fail('Didn\'t catch 404 exception');
+        } catch (NotFoundException $e) {
+        }
+
+        $api->ignoreErrorCode(404);
+        $results = $api->getOne('endpoint', 1);
+
+        $api->restoreDefaultIgnoredErrorCodes();
+
+        try {
+            $results = $api->getOne('endpoint', 1);
+            $this->fail();
+        } catch (NotFoundException $e) {
+        }
+
     }
 }

--- a/tests/Frontend/Api/FailedRequestsTest.php
+++ b/tests/Frontend/Api/FailedRequestsTest.php
@@ -39,22 +39,41 @@ class FailedRequestsTest extends TestCase
         $this->assertEmpty($results);
     }
 
-    public function testFailedResponsesExceoptionCodes()
+    public function testFailedResponsesExceptionCodes401404()
     {
         // Create a mock and queue two responses
         $mock = new MockHandler([
+            new Response(
+                401,
+                [],
+                'Exception error data not found'
+            ),
             new Response(
                 404,
                 [],
                 '{"code":"rest_invalid_param","message":"page not found","data":{"status":404}}'
             ),
+        ]);
+
+        $handler = HandlerStack::create($mock);
+        $client = new Client(['handler' => $handler]);
+
+        $api = new RestApi('somewhere');
+        $api->setClient($client);
+
+        // 401 are ignored by default so shouldn't stop execution
+        $results = $api->getOne('endpoint', 1);
+
+        $this->expectExceptionCode(404);
+        $results = $api->getOne('endpoint', 1);
+    }
+
+    public function testFailedResponsesExceptionCodes500()
+    {
+        // Create a mock and queue two responses
+        $mock = new MockHandler([
             new Response(
                 500,
-                [],
-                'Exception error data not found'
-            ),
-            new Response(
-                401,
                 [],
                 'Exception error data not found'
             ),
@@ -66,14 +85,7 @@ class FailedRequestsTest extends TestCase
         $api = new RestApi('somewhere');
         $api->setClient($client);
 
-        // Test it!
-        $this->expectExceptionCode(404);
-        $results = $api->getOne('endpoint', 1);
-
         $this->expectExceptionCode(500);
-        $results = $api->getOne('endpoint', 1);
-
-        $this->expectExceptionCode(401);
         $results = $api->getOne('endpoint', 1);
     }
 
@@ -148,8 +160,14 @@ class FailedRequestsTest extends TestCase
         } catch (NotFoundException $e) {
         }
 
+        //simply checking execution hasn't stopped above (checking no exception was thrown)
+        $this->assertTrue(true);
+
         $api->ignoreErrorCode(404);
         $results = $api->getOne('endpoint', 1);
+
+        //simply checking execution hasn't stopped above (checking no exception was thrown)
+        $this->assertTrue(true);
 
         $api->restoreDefaultIgnoredErrorCodes();
 
@@ -159,5 +177,7 @@ class FailedRequestsTest extends TestCase
         } catch (NotFoundException $e) {
         }
 
+        //simply checking execution hasn't stopped above (checking no exception was thrown)
+        $this->assertTrue(true);
     }
 }


### PR DESCRIPTION
Adds the ability to temporarily ignore error code (404 for example). I've also refactored the tests in FailedRequestsTest. Some assertions were ignored as exception were stopping execution before they were run.