### PR TITLE
Hotfix/plainarray to string

### DIFF
--- a/src/Frontend/Content/Field/PlainArray.php
+++ b/src/Frontend/Content/Field/PlainArray.php
@@ -79,6 +79,17 @@ class PlainArray extends ContentField
      */
     public function __toString() : string
     {
-        return (string) $this->content;
+        $contentString = '';
+        if (empty($this->content)) {
+            return $contentString;
+        }
+
+        foreach ($this->content as $item) {
+            $contentString .= (string) $item.'. ';
+        }
+
+        $contentString = substr($contentString, 0, -1);
+
+        return $contentString;
     }
 }

--- a/tests/Frontend/Content/Field/PlainArrayTest.php
+++ b/tests/Frontend/Content/Field/PlainArrayTest.php
@@ -51,6 +51,7 @@ class PlainArrayTest extends TestCase
         $intIndexArray = $project->getContent()->get('fruits')->getValue();
 
         $this->assertIsArray($intIndexArray);
+        $this->assertIsString($project->getContent()->get('fruits')->__toString());
 
         foreach ($intIndexArray as $intKey => $itemValue) {
             $this->assertIsInt($intKey);


### PR DESCRIPTION
Plain array field __toString function was not working. Was making an array to string conversion that wouldn't work. Fixed it.