### PR TITLE
Hotfix/open graph tags

### DIFF
--- a/src/Frontend/Content/Head.php
+++ b/src/Frontend/Content/Head.php
@@ -58,7 +58,7 @@ class Head
     public function getMetaHtml(string $name): ?string
     {
         if (isset($this->meta[$name])) {
-            return "<meta name=\"" . $name . "\" content=\"" . $this->meta[$name] . "\">";
+            return $this->createMetaOutput($name, $this->meta[$name], false);
         }
         return null;
     }
@@ -67,7 +67,7 @@ class Head
     {
         $html = "";
         foreach ($this->meta as $name => $content) {
-            $html .= "<meta name=\"" . $name . "\" content=\"" . $content . "\">\n";
+            $html .= $this->createMetaOutput($name, $content);
         }
         return $html;
     }
@@ -92,6 +92,21 @@ class Head
             throw new MetaTagNotAllowedException();
         }
         $this->meta[$name] = $content;
+    }
+
+    private function createMetaOutput(string $name, string $content, bool $linebreak = true): string
+    {
+        $output = '';
+        if (preg_match('/^og:/', $name)) {
+            $output = "<meta property=\"" . $name . "\" content=\"" . $content . "\">";
+        } else {
+            $output = "<meta name=\"" . $name . "\" content=\"" . $content . "\">";
+        }
+
+        if ($linebreak == true) {
+            $output .= "\n";
+        }
+        return $output;
     }
 
     public function __toString(): string

--- a/src/Frontend/Content/Yoast.php
+++ b/src/Frontend/Content/Yoast.php
@@ -56,13 +56,13 @@ class Yoast
     {
         $metatags = "";
         if (isset($this->opengraph["title"]) && strlen($this->opengraph["title"]) > 0) {
-            $metatags .= "<meta name=\"og:title\" content=\"" . $this->opengraph["title"] . "\">";
+            $metatags .= "<meta property=\"og:title\" content=\"" . $this->opengraph["title"] . "\">";
         }
         if (isset($this->opengraph["description"]) && strlen($this->opengraph["description"]) > 0) {
-            $metatags .= "<meta name=\"og:description\" content=\"" . $this->opengraph["description"] . "\">";
+            $metatags .= "<meta property=\"og:description\" content=\"" . $this->opengraph["description"] . "\">";
         }
         if (isset($this->opengraph["image"]) && strlen($this->opengraph["image"]) > 0) {
-            $metatags .= "<meta name=\"og:image\" content=\"" . $this->opengraph["image"] . "\">";
+            $metatags .= "<meta property=\"og:image\" content=\"" . $this->opengraph["image"] . "\">";
         }
         return $metatags;
     }

--- a/tests/Frontend/Cms/HeadPageTest.php
+++ b/tests/Frontend/Cms/HeadPageTest.php
@@ -82,9 +82,9 @@ EOD;
 <meta name="twitter:description" content="Is the miss atmosphere better than the summer?">
 <meta name="twitter:image" content="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAJcAAAB6CAMAAACFmzEXAAAAY1BMVEX///8dofIAnfIAm/EAmPEVn/L5/f/h8f3n9P3x+f6l1fl0v/ZGrvTr9/6XzviJyPdkuPVvvPaSy/i23PpBqvMzp/PT6vy/4PtOsfTH5Pt9wvac0fja7fyKxPZdtfWt2PkAk/BwqbtpAAAEn0lEQVR4nO2byWKrMAxFkW0xE0YzN+n/f+WjIU3TAMEyJn0LzqKr4lwkIcnCWNbBwcHBwcHBwQEZz+3Lsu9d+6+FPOL6aSiBMQRZt7n313JGvEsoOMINZFyc81mrlW9V1Ul2F3XXVlwmysq6e6OsJuQwA/Kz81tVwMBZWGMZO9ALVzsWz7b6sZl//7do8DSymL6+L1odWVEya6xvk8XXm3WrAAZPI7jk9W0J3F//t8llIVuWNcBbq/RTya/xxzWiqxIAgizMq1/LAmBieFBHR7OQLssKvn4AqcKCF06cIHu6rKgY4yEnXeWvWesBFA1dltXcrhaUEIg+CdZi1XiRTUqt9ztHwqMcqJsL4eoJ2/XDiqIrvgeKeroo1YOLya+EGvkJfNJSWPJz6zxUTMrJUj6d0jqNn8LwZLKEJMuqH34DQSkEemVVAIVk1wyGkthohI/3jvykcElHeBgBb3+pqaL+7RMu130p1d14V0fOYM+xgtCtlHGbkiTGNZGeweKJU3j4OsoaQZUFGol1JnMjD14506eUIPhOFVTK2aXgFC1ekVHCflirpvc41nd9nJoMsiVlLUnXrRGjs1BTkEHbzy5J0qXTqI5US+GCjCVzexuaLu39xtCvLoJCtpNqO32Cd9G10ksN/kzz/rGIdJTnkakUkHns1bU5DBtpx7v5dNHxs9du2Dfmq45BHLp1qIPMr0qnpOTVLboUm3Uc1A0gqTqSNw6PeBqVWBFG2zc80cNewjQq9shYJJrdhOnOceB0zQElLWzU0anZXzDOg8tgNHd1A62H7ghRXlNnnZ66cA9Zhaas234IGd/FXCzV1XXax303lPYxszS7pa6rLtIe+xH3RTuxGdR+HC0r3dNgof7YvCFuIygwrQnpiF3sZzB+0del0OZoI5Z3VQqEuxlMbpFlNXsZjGWbdNE6dgK48aWQnexjsWLrez+72EMY3+jGAe+8gyuZxtj+DcIwMfL6NuOG04XYtOX4oa/NKmNmZA3Rn4fMXPxvmABMqVowZTSpNY6bEI0diR11Zhqyrbn+mzhM0jRN6tnxIR2dN7SzVBzJw4cX6Df2z5jtKtDY0ZPcZGJlW8Y4v7HP5gyGtcGTOs7icQgyzOipF2NbXP3h+Dykl/zLoDR83spOzQjTncUtCzMxbDKXuh6EtZuDH8/mZQ3kuM1kKDftGZfp0y0dhc6rWVXKhGtLE9qDJQVsJ6uB6xRxnQNVNGl9HqcJtenhHzvLGimJuoThPD+PR61LfMO0S52emmPfIsuhJliknwWkE2VANBbCltGgGl4sqfWbma/VT9hVysldBQ/3PUnuNXGhseXGbEdZUdl9HYMliwJmuiR6Fz/PqyrPL11QA9Mrish0D7os47bIr+dK2OS0urKxVg5ladIHYku7xWF61N6UslTXWMjl2tG6TZQpNYleVTHZ7dSZ3nFiELRmi4nwLV+YDNkUuKo0xovMwKhZEedyhtVQQ2Qo42ZvBz4RVXEtBJ8Xh8jFJ6T+Wz+4+cFuuvZcDN39D3xIuSDr9JRHf/tBle32ZeWfso82aD8+spNflf/ZN14HBwcHBwcHB/8//wAf2jttaaO4XgAAAABJRU5ErkJggg==">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="og:title" content="This is a title fot the opengraph-title">
-<meta name="og:description" content="A very random description for this field">
-<meta name="og:image" content="http://ogp.me/logo.png">
+<meta property="og:title" content="This is a title fot the opengraph-title">
+<meta property="og:description" content="A very random description for this field">
+<meta property="og:image" content="http://ogp.me/logo.png">
 
 
 EOD;

--- a/tests/Frontend/Content/HeadTest.php
+++ b/tests/Frontend/Content/HeadTest.php
@@ -76,7 +76,7 @@ class HeadTest extends TestCase
         $head->addMeta("og:title", "some title for opengraph");
         $html = $head->getMetaHtml("og:title");
 
-        $this->assertSame("<meta name=\"og:title\" content=\"some title for opengraph\">", $html);
+        $this->assertSame("<meta property=\"og:title\" content=\"some title for opengraph\">", $html);
         $this->assertNull($head->getMetaHtml("non-existing"));
     }
 
@@ -96,9 +96,9 @@ class HeadTest extends TestCase
         $head->addMeta("robots", "noindex, nofollow");
         $head->addMeta("description", "Hello test");
 
-        $this->assertSame("<meta name=\"og:description\" content=\"description\">
-<meta name=\"og:image\" content=\"image\">
-<meta name=\"og:title\" content=\"title\">
+        $this->assertSame("<meta property=\"og:description\" content=\"description\">
+<meta property=\"og:image\" content=\"image\">
+<meta property=\"og:title\" content=\"title\">
 <meta name=\"twitter:card\" content=\"summary\">
 <meta name=\"twitter:description\" content=\"description\">
 <meta name=\"twitter:image\" content=\"description\">

--- a/tests/Frontend/Content/YoastTest.php
+++ b/tests/Frontend/Content/YoastTest.php
@@ -55,7 +55,7 @@ class YoastTest extends TestCase
         $yoast->setOpengraph($post["opengraph-title"], $post["opengraph-description"], $post["opengraph-image"]);
 
         $this->assertSame(
-            '<meta name="og:title" content="10 of your favourite Instagram posts"><meta name="og:description" content="As 2018 comes to a close, we look back at some of your favourite @FaunaFloraInt Instagram posts from the year..."><meta name="og:image" content="https://complex.demo/wp-content/uploads/2018/12/ten-of-your-favourite-instagram-posts-of-2018.png">',
+            '<meta property="og:title" content="10 of your favourite Instagram posts"><meta property="og:description" content="As 2018 comes to a close, we look back at some of your favourite @FaunaFloraInt Instagram posts from the year..."><meta property="og:image" content="https://complex.demo/wp-content/uploads/2018/12/ten-of-your-favourite-instagram-posts-of-2018.png">',
             $yoast->getOpengraph()
         );
         $post = (array)$posts[3]->yoast;
@@ -103,9 +103,9 @@ class YoastTest extends TestCase
 <meta name=\"twitter:title\" content=\"About | Name of site\">
 <meta name=\"twitter:description\" content=\"Focus is on protecting biodiversity, which underpins healthy ecosystems and is critical for the life support systems that all living things rely on.\">
 <meta name=\"twitter:card\" content=\"summary_large_image\">
-<meta name=\"og:title\" content=\"Facebook override title\">
-<meta name=\"og:description\" content=\"Facebook override description\">
-<meta name=\"og:image\" content=\"http://localhost/wp-content/uploads/2018/08/first-chance-to-seeor-last-spectacular-new-footage-of-vietnams-primates-3.png\">
+<meta property=\"og:title\" content=\"Facebook override title\">
+<meta property=\"og:description\" content=\"Facebook override description\">
+<meta property=\"og:image\" content=\"http://localhost/wp-content/uploads/2018/08/first-chance-to-seeor-last-spectacular-new-footage-of-vietnams-primates-3.png\">
 ", $page->getHead()->getAllMetaHtml());
     }
 }


### PR DESCRIPTION
Fixed open graph tags markup - which were not working.
From: `<meta name="" content="">`
To: `<meta property="" content="">`