### PR TITLE
added property page template to WordPress pages

### DIFF
--- a/src/Frontend/Cms/Wordpress.php
+++ b/src/Frontend/Cms/Wordpress.php
@@ -467,6 +467,9 @@ class Wordpress extends ContentRepository
             $page->setExcerpt(FieldFinder::excerpt($data));
         }
 
+        if (!empty(FieldFinder::template($data))) {
+            $page->setTemplate(FieldFinder::template($data));
+        }
 
         if (!empty(FieldFinder::featuredImage($data))) {
             $this->setFeaturedImage($page, FieldFinder::featuredImage($data));

--- a/src/Frontend/Content/Page.php
+++ b/src/Frontend/Content/Page.php
@@ -28,6 +28,12 @@ class Page extends BaseContent
     protected $head;
 
     /**
+     * Template template
+     * @var $template
+     */
+    protected $template;
+
+    /**
      * Page constructor.
      */
     public function __construct()
@@ -148,5 +154,22 @@ class Page extends BaseContent
     {
         $this->author = $author;
         return $this;
+    }
+
+    /**
+     * Set page template
+     *
+     * @param $template
+     * @return Page
+     */
+    public function setTemplate($template): Page
+    {
+        $this->template = $template;
+        return $this;
+    }
+
+    public function getTemplate(): ?string
+    {
+        return $this->template;
     }
 }

--- a/src/Frontend/Utils/WordpressFieldFinder.php
+++ b/src/Frontend/Utils/WordpressFieldFinder.php
@@ -139,6 +139,15 @@ class WordpressFieldFinder
         return self::findFirstFieldFromSearch($searchFields, $data);
     }
 
+    public static function template(array $data, array $searchFields = null): ?string
+    {
+        if (empty($searchFields)) {
+            $searchFields = ['template', 'page_template'];
+        }
+
+        return self::findFirstFieldFromSearch($searchFields, $data);
+    }
+
 
     /**
      * Attempt to find the content field from an array of data

--- a/tests/Frontend/Cms/WordPressTest.php
+++ b/tests/Frontend/Cms/WordPressTest.php
@@ -286,6 +286,7 @@ EOD;
 
         $this->assertEquals($expected, $page->getContent()->__toString());
         $this->assertEquals("Joe Bloggs", $page->getAuthor()->getName());
+        $this->assertEquals('page-template.php', $page->getTemplate());
     }
 
     public function testPageTaxonomy()

--- a/tests/Frontend/responses/acf/pages.json
+++ b/tests/Frontend/responses/acf/pages.json
@@ -29,7 +29,7 @@
     "menu_order": 0,
     "comment_status": "closed",
     "ping_status": "closed",
-    "template": "",
+    "template": "page-template.php",
     "meta": [],
     "acf": [],
     "_links": {


### PR DESCRIPTION
This is a default field in the WP API for pages that allows to check whether a template was assigned to a page.